### PR TITLE
Fixes enb/enb-js#33

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,10 @@
     "enb": ">= 0.15.0 <2.0.0"
   },
   "dependencies": {
+    "babel-core": "6.17.0",
     "browserify": "11.1.0",
     "enb-source-map": "1.8.0",
+    "micromatch": "2.3.11",
     "uglify-js": "2.4.24",
     "vow": "0.4.10",
     "vow-node": "0.3.0",


### PR DESCRIPTION
Example of configuration:

```
[techs.browserJs, {
    target: '?.browser.js',
    sourceSuffixes: ['vanilla.js', 'js', 'browser.js'],
    includeYM: true,
    transpilePatterns: [
        'common.blocks/**/*.js',
        'desktop.blocks/**/*.js',
        'desktop.bundles/**/*.js'
    ],
    transpilePlugins: [
        'transform-es2015-arrow-functions',
        'transform-es2015-block-scoping',
        'transform-es2015-classes'
    ]
}]
```

All transpile plugins must be installed right in your project (not in this enb-js package)

More plugins: http://babeljs.io/docs/plugins/